### PR TITLE
fix: add guardrail to prevent fiddle create from overwriting an existing fiddle

### DIFF
--- a/src/fastly/api/fiddle-api.js
+++ b/src/fastly/api/fiddle-api.js
@@ -31,11 +31,14 @@ export class FastlyFiddleApi {
   }
 
   async create(fiddle) {
+    // ensure no id field is present to force creation of a new fiddle
+    const { id, ...fiddleBody } = fiddle;
+
     const resp = await this.fetch('POST /fiddle', {
       headers: {
         'content-type': 'application/json',
       },
-      body: JSON.stringify(fiddle),
+      body: JSON.stringify(fiddleBody),
     });
     if (!resp.ok) {
       throw new Error(`Failed to create fiddle: ${resp.status} - ${await resp.text()}`);

--- a/src/fastly/fiddle-mgr.js
+++ b/src/fastly/fiddle-mgr.js
@@ -205,8 +205,6 @@ export class FastlyFiddleManager {
     };
 
     // map snippets
-    const { src } = fiddle;
-
     const subs = service.snippetsBySubroutine();
     for (const type in subs) {
       fiddle.src[type] = snippetsToFiddleSrc(subs[type]);
@@ -224,8 +222,8 @@ export class FastlyFiddleManager {
 
       // replace occurrences of F_backend with F_0, F_1, ...
       const reg = new RegExp(`\\bF_${backend.name}\\b`, 'g');
-      for (const type in src) {
-        src[type] = src[type].replaceAll(reg, `F_origin_${i}`);
+      for (const type in fiddle.src) {
+        fiddle.src[type] = fiddle.src[type].replaceAll(reg, `F_origin_${i}`);
       }
 
       backendMapping.push(`# F_origin_${i} => F_${backend.name}`);


### PR DESCRIPTION
`edgly fiddle create` should always create a new fiddle, never accidentally overwrite an existing one.

There isn't any code that today would include the "id" field accidentally. But adding this now to ensure this won't happen in the future by accident.