### PR TITLE
feat: better secrets detection

### DIFF
--- a/src/secrets/patterns.yaml
+++ b/src/secrets/patterns.yaml
@@ -17,6 +17,10 @@ patterns:
       regex: (A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA|ABIA|ACCA)[A-Z0-9]{16}
       confidence: high
   - pattern:
+      name: AWS Secret Key ID Value
+      regex: (?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])
+      confidence: high
+  - pattern:
       name: AWS AppSync GraphQL Key
       regex: da2-[a-z0-9]{26}
       confidence: high


### PR DESCRIPTION
1. detect AWS secret key patterns
    - also contributed back: https://github.com/mazen160/secrets-patterns-db/pull/26
2. separate known secret pattern detection (work on full strings/code snippets) from high entropy potential secrets (work only on hyphenated "words")
    - latter is best effort splitting words using `/[\s:\/\.,&#'"=;]+/`
3. improve/fix warning text