### PR TITLE
fix: add update notification (runs daily)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chalk": "5.4.1",
         "formdata-node": "6.0.3",
         "glob": "11.0.1",
+        "tiny-update-notifier": "^2.0.0",
         "yaml": "2.7.1",
         "yargs": "17.7.2"
       },
@@ -8758,6 +8759,12 @@
         "node": ">=18.20"
       }
     },
+    "node_modules/semiff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semiff/-/semiff-2.0.0.tgz",
+      "integrity": "sha512-ox5jzQW5mbuZdaQq7erRsJHhJfzwXx6ow6Q43NI/eYBLW+6dR2KkWFRE+blTFsvpLspqR4NxTIA4vnCtZ0Ul3w==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -9444,6 +9451,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tiny-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-update-notifier/-/tiny-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-mQ5lY8peg4h9hAAzMa2Jo1ak6sm1a2x59fW1MUQ//h7+dLELplBlu+7Y8LGZn6NXDdXUwOrfU3L6W0Ill6RNZw==",
+      "license": "MIT",
+      "dependencies": {
+        "semiff": "^2.0.0"
       }
     },
     "node_modules/tinyexec": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chalk": "5.4.1",
     "formdata-node": "6.0.3",
     "glob": "11.0.1",
+    "tiny-update-notifier": "^2.0.0",
     "yaml": "2.7.1",
     "yargs": "17.7.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,13 @@
  */
 
 import chalk from 'chalk';
-import updateNotifier from 'tiny-update-notifier';
-import packageJson from '../package.json' with { type: 'json' };
 import fiddle from './commands/fiddle/fiddle.js';
 import service from './commands/service/service.js';
 import test from './commands/test.js';
 import version from './commands/version.js';
 import { GLOBAL_OPTS } from './opts.js';
+import { updateCheck } from './util.js';
 import yargsAhoy from './yargs-ahoy.js';
-
 // colorize console output
 const wrapConsole =
   (original, fn) =>
@@ -29,20 +27,7 @@ const wrapConsole =
 console.warn = wrapConsole(console.warn, chalk.yellow);
 console.error = wrapConsole(console.error, chalk.red);
 
-let updateMsg;
-try {
-  const update = await updateNotifier({ pkg: packageJson });
-  if (update) {
-    updateMsg = '\n';
-    updateMsg += '┌───────────────────────────────────────────────┐\n';
-    updateMsg += ` New version available: ${update.latest}\n`;
-    updateMsg += '\n';
-    updateMsg += ` To update run: npm install -g ${packageJson.name}\n`;
-    updateMsg += '└───────────────────────────────────────────────┘\n';
-  }
-} catch (e) {
-  console.debug('Failed to check for updates:', e);
-}
+await updateCheck();
 
 const yargs = yargsAhoy();
 await yargs
@@ -74,7 +59,6 @@ await yargs
   .epilogue('  Example: --api-token becomes EDGLY_API_TOKEN.')
   .epilogue('')
   .epilogue(`Version: ${version.getVersion()}`)
-  .epilogue(updateMsg ? chalk.yellow(updateMsg) : '')
   .run();
 
 // yargs and/or @adobe/fetch somehow hangs at the end, so we force quit as workaround

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import version from './commands/version.js';
 import { GLOBAL_OPTS } from './opts.js';
 import { updateCheck } from './util.js';
 import yargsAhoy from './yargs-ahoy.js';
+
 // colorize console output
 const wrapConsole =
   (original, fn) =>

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@
  */
 
 import chalk from 'chalk';
+import updateNotifier from 'tiny-update-notifier';
+import packageJson from '../package.json' with { type: 'json' };
 import fiddle from './commands/fiddle/fiddle.js';
 import service from './commands/service/service.js';
 import test from './commands/test.js';
@@ -26,6 +28,21 @@ const wrapConsole =
     original(fn(...args));
 console.warn = wrapConsole(console.warn, chalk.yellow);
 console.error = wrapConsole(console.error, chalk.red);
+
+let updateMsg;
+try {
+  const update = await updateNotifier({ pkg: packageJson });
+  if (update) {
+    updateMsg = '\n';
+    updateMsg += '┌───────────────────────────────────────────────┐\n';
+    updateMsg += ` New version available: ${update.latest}\n`;
+    updateMsg += '\n';
+    updateMsg += ` To update run: npm install -g ${packageJson.name}\n`;
+    updateMsg += '└───────────────────────────────────────────────┘\n';
+  }
+} catch (e) {
+  console.debug('Failed to check for updates:', e);
+}
 
 const yargs = yargsAhoy();
 await yargs
@@ -57,6 +74,7 @@ await yargs
   .epilogue('  Example: --api-token becomes EDGLY_API_TOKEN.')
   .epilogue('')
   .epilogue(`Version: ${version.getVersion()}`)
+  .epilogue(updateMsg ? chalk.yellow(updateMsg) : '')
   .run();
 
 // yargs and/or @adobe/fetch somehow hangs at the end, so we force quit as workaround

--- a/src/util.js
+++ b/src/util.js
@@ -11,6 +11,9 @@
  */
 
 import fs from 'node:fs';
+import chalk from 'chalk';
+import updateNotifier from 'tiny-update-notifier';
+import packageJson from '../package.json' with { type: 'json' };
 
 /**
  * JSON.stringify() but with alphabetically sorted keys.
@@ -157,4 +160,27 @@ export function asMap(array, keyValueFn = (item) => [item, item]) {
     obj[key] = value;
     return obj;
   }, {});
+}
+
+export async function updateCheck() {
+  try {
+    const update = await updateNotifier({ pkg: packageJson });
+    if (update) {
+      process.on('exit', () => {
+        console.log();
+        console.log(chalk.yellow('┌──────────────────────────────────────────────┐'));
+        console.log(chalk.yellow(`│ New version available: ${update.latest}                 │`));
+        console.log(chalk.yellow('│                                              │'));
+        console.log(
+          chalk.yellow('│ To update run:'),
+          chalk.blue(`npm install -g ${packageJson.name}`),
+          chalk.yellow('  │'),
+        );
+        console.log(chalk.yellow('└──────────────────────────────────────────────┘'));
+        console.log();
+      });
+    }
+  } catch (e) {
+    console.debug('Failed to check for updates:', e);
+  }
 }


### PR DESCRIPTION
Show a notification when an update of the tool is available:
```
...
Version: 1.2.0

┌───────────────────────────────────────────────┐
  New version available: 1.2.1

  To update run: npm install -g @adobe/edgly
└───────────────────────────────────────────────┘
```

Checks daily. Using [tiny-update-notifier](https://www.npmjs.com/package/tiny-update-notifier).
