### PR TITLE
fix: clarify current test capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Inside VS Code you can now run tests individually:
 | [dictionaries/private.*.ini](#dictionariesprivateini) | [Private dictionaries](https://docs.fastly.com/en/guides/working-with-dictionaries#private-dictionaries) for secrets |
 | [acl.json](#acljson) | [IP access control lists](https://docs.fastly.com/en/guides/about-acls) |
 | [tests/*.http](#test-framework) | Test files for the [HTTP Test framework](#test-framework) |
+| `tests/fiddle.http` | Test file that will be synced to Fiddle test requests in `edgly fiddle create` and `edgly fiddle get`. To use a different file, set `--test-file <file>`. |
 
 ### Environment variable replacement
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -15,7 +15,8 @@ Prefix any assertion line with `[msg] ` to use a custom assertion message shown 
 ### Status
 
 * `clientFetch.status is 200`
-* `clientFetch.status oneOf [200, 206]`
+
+The [tepi](https://github.com/jupegarnica/tepi) framework used under the hood currently only supports [checking for an exact status code](https://github.com/jupegarnica/tepi/issues/2). Hence Fiddle status expressions with `oneOf`, `isAbove` or `isBelow` are not supported.
 
 ### Headers
 

--- a/src/test/runner.js
+++ b/src/test/runner.js
@@ -84,10 +84,34 @@ function rewriteTest(match, file, line) {
     return `HTTP/1.1 ${value}`;
   }
 
+  /*
+  // can be enabled once https://github.com/jupegarnica/tepi/issues/2 is fixed
+
   // clientFetch.status oneOf [200, 206]
   if (target === 'clientFetch.status' && comparison === 'oneOf') {
     return `<% assertArrayIncludes(${value}, [response.status], '${label || 'Unexpected response status'}') %>`;
   }
+
+  // clientFetch.status isAbove 100
+  if (target === 'clientFetch.status' && comparison === 'isAbove') {
+    return `<% assert(response.status > ${value}, '${label || 'Unexpected response status'}') %>`;
+  }
+
+  // clientFetch.status isAtLeast 100
+  if (target === 'clientFetch.status' && comparison === 'isAtLeast') {
+    return `<% assert(response.status >= ${value}, '${label || 'Unexpected response status'}') %>`;
+  }
+
+  // clientFetch.status isBelow 100
+  if (target === 'clientFetch.status' && comparison === 'isBelow') {
+    return `<% assert(response.status < ${value}, '${label || 'Unexpected response status'}') %>`;
+  }
+
+  // clientFetch.status isAtMost 100
+  if (target === 'clientFetch.status' && comparison === 'isAtMost') {
+    return `<% assert(response.status <= ${value}, '${label || 'Unexpected response status'}') %>`;
+  }
+  */
 
   // clientFetch.resp includes "Content-Type: image/webp"
   if (target === 'clientFetch.resp' && comparison === 'includes') {
@@ -173,21 +197,25 @@ async function rewriteTestsInFile(baseDir, filePath) {
       if (!fiddleTestFound) {
         if (match.groups.target !== 'clientFetch.status' || match.groups.comparison !== 'is') {
           throw new SourceFileError(
-            "First test must assert response status: 'clientFetch.status is XXX'",
+            "First test MUST assert a specific response status: 'clientFetch.status is XXX'",
             filePath,
             i + 1,
           );
         }
+
+        // // above error can be replaced with this below once https://github.com/jupegarnica/tepi/issues/2 is fixed
+        // const statusLine = 'HTTP/1.1';
+        // newLines.push(statusLine);
+        // console.debug('✅', statusLine);
       }
       fiddleTestFound = true;
 
       const newLine = rewriteTest(match, filePath, i + 1);
-      console.debug();
-      console.debug('✅ ', line);
-      console.debug('   ', newLine);
+      console.debug('❌', line);
+      console.debug('✅', newLine);
       newLines.push(newLine);
     } else {
-      console.debug('❌ ', line);
+      console.debug('  ', line);
       newLines.push(line);
     }
   }


### PR DESCRIPTION
- test assertion `clientFetch.status oneOf [200, 206]` is not actually supported
- due to https://github.com/jupegarnica/tepi/issues/2
- added code in comments to support more once the above is fixed in `tepi`
- document special `tests/fiddle.http` file
- more readable `-v` debug logging for test file rewriting
