### PR TITLE
chore(deps): keep semantic-release at 24.2.3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "ignoreDeps": ["semantic-release"],
   "extends": [
     "config:recommended",
     ":semanticCommits",


### PR DESCRIPTION
Latest semantic release 24.2.7 leads to this build error: https://github.com/adobe/edgly/actions/runs/17383609025/job/49346150928

Seen over in #53.

Due to https://github.com/semantic-release/semantic-release/issues/3725

Keeping it at a safe version for now.