### PR TITLE
chore: migrate to biome v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,23 +1,25 @@
 {
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "files": {
-    "ignore": ["renovate.json"]
+    "includes": ["**", "!**/renovate.json"]
   },
   "linter": {
     "rules": {
-      "all": true,
+      "recommended": true,
       "correctness": {
         "noUndeclaredVariables": "error",
         "noNodejsModules": "off"
       },
       "suspicious": {
         "noConsole": "off",
-        "noConsoleLog": "off"
+        "noTemplateCurlyInString": "off"
       },
       "performance": {
         "useTopLevelRegex": "off"
       },
       "complexity": {
         "noExcessiveCognitiveComplexity": {
+          "level": "error",
           "options": {
             "maxAllowedComplexity": 20
           }
@@ -26,7 +28,7 @@
     }
   },
   "formatter": {
-    "ignore": ["package.json", "license-checker-config.json"],
+    "includes": ["**", "!**/package.json", "!**/license-checker-config.json"],
     "indentStyle": "space",
     "lineWidth": 120
   },
@@ -38,7 +40,7 @@
   },
   "overrides": [
     {
-      "include": ["test/**/*.js"],
+      "includes": ["**/test/**/*.js"],
       "javascript": {
         "globals": ["afterEach", "afterAll", "beforeEach", "beforeAll", "describe", "it"]
       },
@@ -51,7 +53,7 @@
       }
     },
     {
-      "include": ["src/commands/*.js"],
+      "includes": ["**/src/commands/**/*.js"],
       "linter": {
         "rules": {
           "style": {
@@ -61,7 +63,7 @@
       }
     },
     {
-      "include": ["src/fastly/service.js"],
+      "includes": ["**/src/fastly/service.js"],
       "linter": {
         "rules": {
           "style": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "edgly": "src/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.9.4",
+        "@biomejs/biome": "2.4.13",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@semantic-release/changelog": "6.0.3",
@@ -94,11 +94,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -111,20 +110,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
       "cpu": [
         "arm64"
       ],
@@ -139,9 +138,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
       "cpu": [
         "x64"
       ],
@@ -156,9 +155,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +172,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
       "cpu": [
         "arm64"
       ],
@@ -190,9 +189,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
       "cpu": [
         "x64"
       ],
@@ -207,9 +206,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
       "cpu": [
         "x64"
       ],
@@ -224,9 +223,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
       "cpu": [
         "arm64"
       ],
@@ -241,9 +240,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.4.13",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@semantic-release/changelog": "6.0.3",

--- a/src/commands/service/create.js
+++ b/src/commands/service/create.js
@@ -13,7 +13,7 @@
 import chalk from 'chalk';
 import { FastlyServiceManager } from '../../fastly/service-mgr.js';
 import { readService } from '../../fastly/store.js';
-import { SHARED_OPTS, override } from '../../opts.js';
+import { override, SHARED_OPTS } from '../../opts.js';
 
 export default {
   command: 'create',

--- a/src/commands/service/get.js
+++ b/src/commands/service/get.js
@@ -13,7 +13,7 @@
 import chalk from 'chalk';
 import { FastlyServiceManager } from '../../fastly/service-mgr.js';
 import { writeService } from '../../fastly/store.js';
-import { SHARED_OPTS, override } from '../../opts.js';
+import { override, SHARED_OPTS } from '../../opts.js';
 import { detectSecrets } from '../../secrets/secrets.js';
 
 export default {

--- a/src/commands/service/update.js
+++ b/src/commands/service/update.js
@@ -14,7 +14,7 @@ import { execSync } from 'node:child_process';
 import chalk from 'chalk';
 import { FastlyServiceManager } from '../../fastly/service-mgr.js';
 import { readService } from '../../fastly/store.js';
-import { SHARED_OPTS, override } from '../../opts.js';
+import { override, SHARED_OPTS } from '../../opts.js';
 
 function getLastGitCommit() {
   try {

--- a/src/fastly/api/fastly-api.js
+++ b/src/fastly/api/fastly-api.js
@@ -279,7 +279,6 @@ export class FastlyApi {
       // create dict
       const body = toFormData({
         name: dictName,
-        // biome-ignore lint/style/useNamingConvention: fastly json naming
         write_only: String(writeOnly),
       });
       resp = await this.fetch(`POST /service/${serviceId}/version/${versionId}/dictionary`, { body });
@@ -289,7 +288,6 @@ export class FastlyApi {
     }
     const { id } = await resp.json();
 
-    // biome-ignore lint/style/useNamingConvention: fastly json naming
     const items = Object.entries(entries).map(([key, value]) => ({ op: 'upsert', item_key: key, item_value: value }));
 
     while (items.length > 0) {

--- a/src/fastly/fiddle-mgr.js
+++ b/src/fastly/fiddle-mgr.js
@@ -106,14 +106,13 @@ function tablesToDictionaries(init, service, opts) {
 
   const dicts = [];
 
-  const tablesRegex = /table (\w+) \{[^\}]*\}/gm;
+  const tablesRegex = /table (\w+) \{[^}]*\}/gm;
   const entriesRegex = /^\s*"([^"]*)"\s*:\s*"([^"]*)"\s*,.*$/gm;
 
   for (const table of init.matchAll(tablesRegex)) {
     const name = table[1];
     const dict = {
       name,
-      // biome-ignore lint/style/useNamingConvention: fastly json schema
       write_only: currentDicts[name]?.write_only,
       items: [],
       info: {},
@@ -128,9 +127,7 @@ function tablesToDictionaries(init, service, opts) {
     const entries = table[0].matchAll(entriesRegex);
     for (const entry of entries) {
       dict.items.push({
-        // biome-ignore lint/style/useNamingConvention: fastly json schema
         item_key: entry[1],
-        // biome-ignore lint/style/useNamingConvention: fastly json schema
         item_value: entry[2],
       });
     }
@@ -188,12 +185,9 @@ function fiddleOriginsToBackends(fiddle, service) {
         name,
         address: origin.hostname,
         hostname: origin.hostname,
-        port: origin.port === '' ? (origin.protocol === 'https:' ? 443 : 80) : Number.parseInt(origin.port),
-        // biome-ignore lint/style/useNamingConvention: fastly json schema
+        port: origin.port === '' ? (origin.protocol === 'https:' ? 443 : 80) : Number.parseInt(origin.port, 10),
         use_ssl: origin.protocol === 'https:',
-        // biome-ignore lint/style/useNamingConvention: fastly json schema
         ssl_cert_hostname: origin.protocol === 'https:' ? origin.hostname : null,
-        // biome-ignore lint/style/useNamingConvention: fastly json schema
         ssl_sni_hostname: origin.protocol === 'https:' ? origin.hostname : null,
       });
     }

--- a/src/fastly/store.js
+++ b/src/fastly/store.js
@@ -331,7 +331,6 @@ function writeDictionaries(dictionaries) {
 }
 
 function readDictionary(dictPath) {
-  // biome-ignore lint/style/useNamingConvention: fastly json naming
   let write_only = false;
   let filename = path.basename(dictPath, '.ini');
   if (filename.startsWith(PRIVATE_DICT_PREFIX)) {
@@ -355,9 +354,7 @@ function readDictionary(dictPath) {
       const keyValueMatch = line.match(/([^=]+)="(.*)"/);
       if (keyValueMatch) {
         dict.items.push({
-          // biome-ignore lint/style/useNamingConvention: fastly json naming
           item_key: keyValueMatch[1],
-          // biome-ignore lint/style/useNamingConvention: fastly json naming
           item_value: keyValueMatch[2],
         });
       }

--- a/src/secrets/secrets.js
+++ b/src/secrets/secrets.js
@@ -133,7 +133,7 @@ function findSecretsInString(input) {
   matches.push(...findKnownSecretPatterns(input));
 
   // 2. find high entropy strings. need to split into "words" first
-  for (const word of input.split(/[\s:\/\.,&#'"=;]+/)) {
+  for (const word of input.split(/[\s:/.,&#'"=;]+/)) {
     // if (matches.length === 0) {
     const match = findHighEntropy(word, cfg?.entropy_threshold);
     if (match) {

--- a/src/test/runner.js
+++ b/src/test/runner.js
@@ -244,7 +244,6 @@ export async function runTests(globs, tepiArgs = []) {
   }
 
   // if absolute path is used (eg. by tepi VS Code extension), make it relative
-  // biome-ignore lint/style/noParameterAssign: it's easier this way :)
   globs = globs.map((g) => removePrefix(g, `${process.cwd()}/`));
 
   try {

--- a/src/yargs-ahoy.js
+++ b/src/yargs-ahoy.js
@@ -25,7 +25,6 @@ function isFile(path) {
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false; // File doesn't exist
-      // biome-ignore lint/style/noUselessElse: mistakenly flagged
     } else {
       throw err; // Other errors
     }
@@ -38,7 +37,6 @@ function isDirectory(path) {
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false; // Directory doesn't exist
-      // biome-ignore lint/style/noUselessElse: mistakenly flagged
     } else {
       throw err; // Other errors
     }
@@ -97,7 +95,6 @@ function onFail(msg, err, yargs) {
   } else {
     // yargs validation errors (only message, no err)
     for (const [newMsg, oldMsg] of Object.entries(BETTER_FAIL_MESSAGES)) {
-      // biome-ignore lint/style/noParameterAssign: it's easier this way :)
       msg = msg.replace(oldMsg, newMsg);
     }
 
@@ -155,7 +152,6 @@ function handleAdditionalTypes(_yargs, opt) {
  *   - exit with code 2 on application errors
  * - TODO: document other stuff
  */
-// biome-ignore lint/style/noDefaultExport: we mimic yargs here
 export default function yargsAhoy(processArgs, cwd, parentRequire) {
   const yargs = _yargs(processArgs, cwd, parentRequire);
 

--- a/test/secrets.test.js
+++ b/test/secrets.test.js
@@ -14,7 +14,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { LOG_SECRET_FIELDS, detectSecrets } from '../src/secrets/secrets.js';
+import { detectSecrets, LOG_SECRET_FIELDS } from '../src/secrets/secrets.js';
 
 // silence debug/warn output for these tests
 console.debug = () => ({});

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -19,7 +19,7 @@ class StreamCatcher {
     this.streamWrite = stream._write;
 
     this.buffer = Buffer.alloc(0);
-    // biome-ignore lint/complexity/noUselessThisAlias: <explanation>
+    // biome-ignore lint/complexity/noUselessThisAlias: needed for arrow function closure below
     const self = this;
 
     stream._write = (chunk, encoding, callback) => {
@@ -50,7 +50,7 @@ class StreamCatcher {
 class ExitCatcher {
   constructor() {
     this.processExit = process.exit;
-    // biome-ignore lint/complexity/noUselessThisAlias: <explanation>
+    // biome-ignore lint/complexity/noUselessThisAlias: needed for arrow function closure below
     const self = this;
     process.exit = (code) => {
       self.code = code;


### PR DESCRIPTION
## Summary
- Upgrade `@biomejs/biome` 1.9.4 → 2.4.13
- Migrate `biome.json` to v2 schema: `includes` (with negated globs) replaces `ignore`, override `include` → `includes` with `**/` prefix per v2's new glob semantics, `recommended: true` replaces removed `"all": true`, drop `noConsoleLog` (merged into `noConsole`), disable `noTemplateCurlyInString` (false positives on edgly's own `${{VAR}}` templating syntax)
- Remove unused `biome-ignore` comments and fix `<explanation>` placeholders that v2 now flags
- Minor lint autofixes: import sorting, useless regex escapes, `parseInt` radix

## Test plan
- [x] `npm run lint` passes
- [x] `npm run lint-ci` passes
- [x] `npm test` passes (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)